### PR TITLE
Hex literals outside strings should not be enclosed in quotes

### DIFF
--- a/Text/Jasmine/Pretty.hs
+++ b/Text/Jasmine/Pretty.hs
@@ -55,7 +55,7 @@ rn (JSOctal o)             = text o
 rn (JSLiteral "new")       = (text "new ")
 rn (JSLiteral l)           = (text l)
 
-rn (JSHexInteger i)        = (text $ show i) -- TODO: need to tweak this
+rn (JSHexInteger i)        = (text i)
 rn (JSStringLiteral s l)   = empty <> (char s) <> (text l) <> (char s)
 rn (JSRegEx s)             = (text s)
 

--- a/runtests.hs
+++ b/runtests.hs
@@ -47,6 +47,7 @@ testSuite = testGroup "Text.Jasmine.Parse"
     , testCase "Issue8"           caseIssue8
     , testCase "Issue9"           caseIssue9
     , testCase "Issue14"          caseIssue14
+    , testCase "Issue22"          caseIssue22
     ]
 
 testSuiteMin :: Test
@@ -77,6 +78,7 @@ testSuiteMin = testGroup "Text.Jasmine.Pretty Min"
     , testCase "MinIssue8"        caseMinIssue8
     , testCase "MinIssue9"        caseMinIssue9
     , testCase "MinIssue14"       caseMinIssue14
+    , testCase "MinIssue22"       caseMinIssue22
 
     ]
 
@@ -342,6 +344,15 @@ caseIssue14 =
 
 caseMinIssue14 =
     testMinify "var settings={start:new Date(2012,01,27)}" srcIssue14
+
+srcIssue22 = "0xe0+'0x30'"
+
+caseIssue22 =
+    "Right (JSSourceElementsTop [JSExpression [JSExpressionBinary \"+\" [JSHexInteger \"0xe0\"] [JSStringLiteral '\\'' \"0x30\"]],JSLiteral \"\"])"
+    @=? showStrippedMaybe (parseProgram srcIssue22)
+
+caseMinIssue22 =
+    testMinify srcIssue22 srcIssue22
 
 
 -- ---------------------------------------------------------------------

--- a/runtests.hs
+++ b/runtests.hs
@@ -47,7 +47,7 @@ testSuite = testGroup "Text.Jasmine.Parse"
     , testCase "Issue8"           caseIssue8
     , testCase "Issue9"           caseIssue9
     , testCase "Issue14"          caseIssue14
-    , testCase "Issue22"          caseIssue22
+    , testCase "Issue24"          caseIssue24
     ]
 
 testSuiteMin :: Test
@@ -78,7 +78,7 @@ testSuiteMin = testGroup "Text.Jasmine.Pretty Min"
     , testCase "MinIssue8"        caseMinIssue8
     , testCase "MinIssue9"        caseMinIssue9
     , testCase "MinIssue14"       caseMinIssue14
-    , testCase "MinIssue22"       caseMinIssue22
+    , testCase "MinIssue24"       caseMinIssue24
 
     ]
 
@@ -345,14 +345,14 @@ caseIssue14 =
 caseMinIssue14 =
     testMinify "var settings={start:new Date(2012,01,27)}" srcIssue14
 
-srcIssue22 = "0xe0+'0x30'"
+srcIssue24 = "0xe0+'0x30'"
 
-caseIssue22 =
+caseIssue24 =
     "Right (JSSourceElementsTop [JSExpression [JSExpressionBinary \"+\" [JSHexInteger \"0xe0\"] [JSStringLiteral '\\'' \"0x30\"]],JSLiteral \"\"])"
-    @=? showStrippedMaybe (parseProgram srcIssue22)
+    @=? showStrippedMaybe (parseProgram srcIssue24)
 
-caseMinIssue22 =
-    testMinify srcIssue22 srcIssue22
+caseMinIssue24 =
+    testMinify srcIssue24 srcIssue24
 
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
Hex literals were being put in quotes, making them string literals instead of integer literals.  The parser returns the literal as a String, so it doesn't need the ```show``` (there was already a comment in the code that this needed attention).

Test case added too.