### PR TITLE
support text 2.x

### DIFF
--- a/hjsmin.cabal
+++ b/hjsmin.cabal
@@ -1,5 +1,5 @@
 name:            hjsmin
-version:         0.2.0.4
+version:         0.2.1
 license:         BSD3
 license-file:    LICENSE
 author:          Alan Zimmerman <alan.zimm@gmail.com>

--- a/hjsmin.cabal
+++ b/hjsmin.cabal
@@ -29,7 +29,7 @@ library
 
   exposed-modules:      Text.Jasmine
 
-  build-depends:        base                    >= 4.8          && < 5
+  build-depends:        base                    >= 4.9          && < 5
                       , bytestring              >=0.11
                       , language-javascript     >= 0.6          && < 0.8
                       , text                    >= 2

--- a/hjsmin.cabal
+++ b/hjsmin.cabal
@@ -30,9 +30,9 @@ library
   exposed-modules:      Text.Jasmine
 
   build-depends:        base                    >= 4.8          && < 5
-                      , bytestring              == 0.10.*
+                      , bytestring              >=0.11
                       , language-javascript     >= 0.6          && < 0.8
-                      , text                    == 1.2.*
+                      , text                    >= 2
 
 
 executable hjsmin
@@ -44,8 +44,8 @@ executable hjsmin
   -- Need this here because the library and the executable have the same name.
   other-modules:        Text.Jasmine
 
-  build-depends:        base                    >= 4.8          && < 5
-                      , bytestring              == 0.10.*
+  build-depends:        base
+                      , bytestring
                       , language-javascript
                       , optparse-applicative    >= 0.7
                       , text

--- a/main/hjsmin.hs
+++ b/main/hjsmin.hs
@@ -3,7 +3,6 @@
 #include "cabal_macros.h"
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.Monoid ((<>))
 import           Options.Applicative (Parser, ParserInfo, ParserPrefs)
 import qualified Options.Applicative as Opt
 import           Text.Jasmine (minify)

--- a/src/Text/Jasmine.hs
+++ b/src/Text/Jasmine.hs
@@ -5,8 +5,6 @@ module Text.Jasmine
     , minifyFile
     ) where
 
-import           Control.Applicative ((<$>))
-
 import           Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy.Char8 as LBS


### PR DESCRIPTION
- support and require text 2+, bytestring 0.11+
- require base 4.9+, GHC 8.0+
- fix redundant import warnings
- bump suggested new version to 0.2.1

This builds with stackage nightly-2022-12-26 and fixes #38.